### PR TITLE
Feature/Add ZIP Format Support for Virtual Tours

### DIFF
--- a/djangoplicity/products2/models.py
+++ b/djangoplicity/products2/models.py
@@ -234,6 +234,7 @@ class VirtualTour(ArchiveModel, TranslationModel, StandardArchiveInfo, PrintInfo
         tour = ResourceManager( type=types.VirtualTourType )
         exe = ResourceManager(type=types.ExeType)
         bz2 = ResourceManager(type=types.Bz2Type)
+        zip = ResourceManager(type=types.ZipType)
 
         class Meta( StandardArchiveInfo.Archive.Meta ):
             root = archive_settings.VIRTUAL_TOUR_ROOT

--- a/djangoplicity/products2/models.py
+++ b/djangoplicity/products2/models.py
@@ -234,7 +234,8 @@ class VirtualTour(ArchiveModel, TranslationModel, StandardArchiveInfo, PrintInfo
         tour = ResourceManager( type=types.VirtualTourType )
         exe = ResourceManager(type=types.ExeType)
         bz2 = ResourceManager(type=types.Bz2Type)
-        zip = ResourceManager(type=types.ZipType)
+        zip_windows = ResourceManager( type=types.ZipType, verbose_name=_( 'Zip file for Windows' ))
+        zip_mac = ResourceManager( type=types.ZipType, verbose_name=_('Zip file for MacOS') )
 
         class Meta( StandardArchiveInfo.Archive.Meta ):
             root = archive_settings.VIRTUAL_TOUR_ROOT

--- a/djangoplicity/products2/options.py
+++ b/djangoplicity/products2/options.py
@@ -127,9 +127,15 @@ class VirtualTourOptions( VirtualTourOptionsSC ):
     downloads = (
         (_(u'Images'), {'resources': ('original', 'large', 'screen'),
                         'icons': {'original': 'phot', 'large': 'phot', 'medium': 'phot', 'screen': 'phot'}}),
-        (_(u'File Formats'), {'resources': ('bz2', 'exe', 'zip'),
-                              'icons': {'bz2': 'install', 'exe': 'install', 'zip': 'zip'}}),
+        (_(u'File Formats'), {'resources': ('bz2', 'exe', 'zip_windows', 'zip_mac'),
+                              'icons': {'bz2': 'install', 'exe': 'install', 'zip_windows': 'zip', 'zip_mac': 'zip'}}),
     )
+
+    class Import(StandardOptions.Import):
+        scan_directories = StandardOptions.Import.scan_directories + [
+            ('zip_windows', ('.zip',)),
+            ('zip_mac', ('.zip',)),
+        ]
 
 
 class ApplicationOptions (StandardOptions):

--- a/djangoplicity/products2/options.py
+++ b/djangoplicity/products2/options.py
@@ -127,8 +127,8 @@ class VirtualTourOptions( VirtualTourOptionsSC ):
     downloads = (
         (_(u'Images'), {'resources': ('original', 'large', 'screen'),
                         'icons': {'original': 'phot', 'large': 'phot', 'medium': 'phot', 'screen': 'phot'}}),
-        (_(u'File Formats'), {'resources': ('bz2', 'exe'),
-                              'icons': {'bz2': 'install', 'exe': 'install'}}),
+        (_(u'File Formats'), {'resources': ('bz2', 'exe', 'zip'),
+                              'icons': {'bz2': 'install', 'exe': 'install', 'zip': 'zip'}}),
     )
 
 


### PR DESCRIPTION
Add zip format type for Virtual Tours, overriding scan directories allowing zip file for windows and macos.

## Screenshot
<img width="970" height="506" alt="image" src="https://github.com/user-attachments/assets/89949fb3-e781-413b-912f-052116730d4a" />
