### PR TITLE
Feature/Add 3d model with STL format

### DIFF
--- a/djangoplicity/products2/models.py
+++ b/djangoplicity/products2/models.py
@@ -1609,6 +1609,7 @@ class Model3d( ArchiveModel, StandardArchiveInfo ):
     class Archive( StandardArchiveInfo.Archive ):
         model_3d_obj = ResourceManager( type=types.Model3dObjType )
         model_3d_c4d = ResourceManager( type=types.Model3dC4DType )
+        model_3d_stl = ResourceManager( type=types.Model3dStlType )
 
         class Meta( StandardArchiveInfo.Archive.Meta ):
             root = archive_settings.MODEL3D_FILM_ROOT

--- a/djangoplicity/products2/options.py
+++ b/djangoplicity/products2/options.py
@@ -525,7 +525,7 @@ class Model3dOptions ( StandardOptions ):
 
     downloads = (
         ( _(u'Images'), {'resources': ('large', 'original'), 'icons': { 'large': 'phot', 'original': 'phot' } } ),
-        ( _(u'3D Model Files'), {'resources': ( 'model_3d_c4d', 'model_3d_obj' ), 'icons': { 'model_3d_c4d': 'phot', 'model_3d_obj': 'phot' } } )
+        ( _(u'3D Model Files'), {'resources': ( 'model_3d_c4d', 'model_3d_obj', 'model_3d_stl' ), 'icons': { 'model_3d_c4d': 'phot', 'model_3d_obj': 'phot', 'model_3d_stl': 'phot' } } )
     )
 
     class Queries(object):
@@ -538,6 +538,7 @@ class Model3dOptions ( StandardOptions ):
             ( 'original', ( '.jpg', '.jpeg', '.tif', '.tiff', '.png', ) ),
             ( 'model_3d_c4d', ( '.c4d', '.zip') ),
             ( 'model_3d_obj', ( '.obj', '.zip') ),
+            ( 'model_3d_stl', ( '.stl', '.zip') ),
         ]
         actions = [
             move_resources,


### PR DESCRIPTION
Add a 3D model using the STL format (Stereolithography) to the options and to the `Model3d` model in products.
