### PR TITLE
Feature/improvements scope periodical

### DIFF
--- a/djangoplicity/products2/models.py
+++ b/djangoplicity/products2/models.py
@@ -912,8 +912,8 @@ class Mirror( ArchiveModel, StandardArchiveInfo, PhysicalInfo, PrintInfo ):
 # =============================================================
 class TheScope( ArchiveModel, StandardArchiveInfo, PhysicalInfo, PrintInfo ):
     class Archive( StandardArchiveInfo.Archive ):
-        pdf = ResourceManager( type=types.PDFType )
-        pdfsm = ResourceManager( type=types.PDFType, verbose_name=_( 'PDF File (Small)' ) )
+        pdf = ResourceManager( type=types.PDFType, verbose_name=_( 'PDF Print version' ) )
+        pdfsm = ResourceManager( type=types.PDFType, verbose_name=_( 'PDF Print version (Small)' ) )
         epub = ResourceManager(type=types.EPUBType)
         original = ImageResourceManager( verbose_name=_( 'Fullsize (RGB)' ), type=types.OriginalImageType )
         large = ImageResourceManager( derived='original', type=types.LargeJpegType )

--- a/djangoplicity/products2/models.py
+++ b/djangoplicity/products2/models.py
@@ -912,8 +912,8 @@ class Mirror( ArchiveModel, StandardArchiveInfo, PhysicalInfo, PrintInfo ):
 # =============================================================
 class TheScope( ArchiveModel, StandardArchiveInfo, PhysicalInfo, PrintInfo ):
     class Archive( StandardArchiveInfo.Archive ):
-        pdf = ResourceManager( type=types.PDFType, verbose_name=_( 'PDF Print version' ) )
-        pdfsm = ResourceManager( type=types.PDFType, verbose_name=_( 'PDF Print version (Small)' ) )
+        pdf = ResourceManager( type=types.PDFType )
+        pdfsm = ResourceManager( type=types.PDFType, verbose_name=_( 'PDF File (Small)' ) )
         epub = ResourceManager(type=types.EPUBType)
         original = ImageResourceManager( verbose_name=_( 'Fullsize (RGB)' ), type=types.OriginalImageType )
         large = ImageResourceManager( derived='original', type=types.LargeJpegType )

--- a/djangoplicity/products2/models.py
+++ b/djangoplicity/products2/models.py
@@ -914,6 +914,7 @@ class TheScope( ArchiveModel, StandardArchiveInfo, PhysicalInfo, PrintInfo ):
     class Archive( StandardArchiveInfo.Archive ):
         pdf = ResourceManager( type=types.PDFType )
         pdfsm = ResourceManager( type=types.PDFType, verbose_name=_( 'PDF File (Small)' ) )
+        pdf2up = ResourceManager( type=types.PDFType, verbose_name=_('PDF for Reading (Two-Page Spread)') )
         epub = ResourceManager(type=types.EPUBType)
         original = ImageResourceManager( verbose_name=_( 'Fullsize (RGB)' ), type=types.OriginalImageType )
         large = ImageResourceManager( derived='original', type=types.LargeJpegType )

--- a/djangoplicity/products2/models.py
+++ b/djangoplicity/products2/models.py
@@ -914,7 +914,7 @@ class TheScope( ArchiveModel, StandardArchiveInfo, PhysicalInfo, PrintInfo ):
     class Archive( StandardArchiveInfo.Archive ):
         pdf = ResourceManager( type=types.PDFType )
         pdfsm = ResourceManager( type=types.PDFType, verbose_name=_( 'PDF File (Small)' ) )
-        pdf2up = ResourceManager( type=types.PDFType, verbose_name=_('PDF for Reading (Two-Page Spread)') )
+        pdf2up = ResourceManager( type=types.PDFType, verbose_name=_('2-up PDF') )
         epub = ResourceManager(type=types.EPUBType)
         original = ImageResourceManager( verbose_name=_( 'Fullsize (RGB)' ), type=types.OriginalImageType )
         large = ImageResourceManager( derived='original', type=types.LargeJpegType )

--- a/djangoplicity/products2/options.py
+++ b/djangoplicity/products2/options.py
@@ -83,6 +83,7 @@ class PeriodicalOptions(StandardOptions):
     class Import(StandardOptions.Import):
         scan_directories = StandardOptions.Import.scan_directories + [
             ('webapp', ('',)),
+            ('pdf2up', ('.pdf',)),
         ]
     
     def get_detail_template(obj):
@@ -145,8 +146,8 @@ TheScopeOptionsSC = product_options( "thescope", "The Scope", "The Scope", True,
 class TheScopeOptions( TheScopeOptionsSC ):
     downloads = (
         ( _(u'PDF Files'), {
-            'resources': ('pdf', 'pdfsm'), 
-            'icons': { 'pdf': 'pdf', 'pdfsm': 'pdf' } 
+            'resources': ('pdf2up', 'pdfsm', 'pdf'), 
+            'icons': { 'pdf2up': 'pdf', 'pdfsm': 'pdf', 'pdf': 'pdf' } 
         } ),
         ( _(u'EPUB Files'), {
             'resources': ('epub',), 

--- a/djangoplicity/products2/options.py
+++ b/djangoplicity/products2/options.py
@@ -139,7 +139,23 @@ MirrorOptions = product_options( "mirrors", "The Mirror", "The Mirror", True, ba
 GeminiFocusOptions = product_options( "geminifocus", "Gemini Focus", "Gemini Focus", True, base_options=PeriodicalOptions )
 NOAONewsletterOptions = product_options( "noaonewsletters", "NOAO Newsletter", "NOAO Newsletters", True, base_options=PeriodicalOptions )
 TONNewsletterOptions = product_options( "tonnewsletters", "TON Newsletter", "TON Newsletters", True, base_options=PeriodicalOptions )
-TheScopeOptions = product_options( "thescope", "The Scope", "The Scope", True, base_options=PeriodicalOptions )
+TheScopeOptionsSC = product_options( "thescope", "The Scope", "The Scope", True, base_options=PeriodicalOptions )
+
+
+class TheScopeOptions( TheScopeOptionsSC ):
+    downloads = (
+        ( _(u'PDF Files'), {
+            'resources': ('pdf', 'pdfsm'), 
+            'icons': { 'pdf': 'pdf', 'pdfsm': 'pdf' } 
+        } ),
+        ( _(u'EPUB Files'), {
+            'resources': ('epub',), 
+            'icons': { 'epub': 'epub' } 
+        } ),
+    )
+    
+    def get_detail_template(obj):
+        return "archives/periodicals/detail_webapp.html"
 
 
 class VirtualTourOptions( VirtualTourOptionsSC ):


### PR DESCRIPTION
- Overwrite options only for TheScope model. Removing images from download resources and add new resource (pdf2up, Two-Page Spread)
- Make mandatory always use as default the webapp template for the Scope. 


<img width="1280" height="611" alt="image" src="https://github.com/user-attachments/assets/82bbde52-ab65-4eac-a334-ccf1116ca83a" />
